### PR TITLE
feat: add dependabot config; fix: step fails when nothing to commit

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"

--- a/.github/workflows/update-contributors.yml
+++ b/.github/workflows/update-contributors.yml
@@ -31,6 +31,11 @@ jobs:
     - name: Run script
       run: npm run start
 
+    - uses: actions/upload-artifact@v4
+      with:
+         name: contributors.json
+         path: contributors.json
+  
     - name: Commit and push if it changed
       if: github.repository == 'Vanilla-OS/.github' && github.ref == 'refs/heads/main'
       continue-on-error: true

--- a/.github/workflows/update-contributors.yml
+++ b/.github/workflows/update-contributors.yml
@@ -10,7 +10,6 @@ env:
 
 permissions:
   contents: write
-  
 
 jobs:
   update-contributors:
@@ -32,6 +31,7 @@ jobs:
       run: npm run start
 
     - name: Commit and push if it changed
+      continue-on-error: true
       run: |
         git config user.name github-actions
         git config user.email github-actions@github.com

--- a/.github/workflows/update-contributors.yml
+++ b/.github/workflows/update-contributors.yml
@@ -3,6 +3,7 @@ name: Update Contributors
 on:
   schedule:
     - cron: '0 0 * * 0'
+  pull_request:
   workflow_dispatch:
     
 env:
@@ -31,6 +32,7 @@ jobs:
       run: npm run start
 
     - name: Commit and push if it changed
+      if: github.repository == 'Vanilla-OS/.github' && github.ref == 'refs/heads/main'
       continue-on-error: true
       run: |
         git config user.name github-actions


### PR DESCRIPTION
## Changes

- Adds dependabot configuration file for GitHub actions.
- Set the `continue-on-error` parameter to true for the "Commit and push" step of the Contributors list workflow, this will prevent it from failing and sending us notifications when there are no new contributors to commit. [Note: this doesn't affect the script run step itself, as it can still fail (allowing us to debug any issues) and this parameter uses the default false over there.]