### PR TITLE
cleanup: replace #gh-[theme]-mode-only for cover

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -1,6 +1,9 @@
 <div align="center">
-  <img src="https://github.com/Vanilla-OS/.github/blob/main/profile/cover.png#gh-light-mode-only">
-  <img src="https://github.com/Vanilla-OS/.github/blob/main/profile/cover-dark.png#gh-dark-mode-only">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="https://github.com/Vanilla-OS/.github/blob/main/profile/cover-dark.png">
+    <source media="(prefers-color-scheme: light)" srcset="https://github.com/Vanilla-OS/.github/blob/main/profile/cover.png">
+    <img alt="Vanilla OS is your next operating system" src="https://github.com/Vanilla-OS/.github/blob/main/profile/cover.png">
+  </picture>
   <p>Vanilla OS is an immutable and atomic Linux operating system with user experience as the main focus.</p>
 </div>
 


### PR DESCRIPTION
The old method of using a fragment appended to the URL (#gh-dark-mode-only or #gh-light-mode-only), is deprecated. See: https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#specifying-the-theme-an-image-is-shown-to